### PR TITLE
Documentation Updated

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -31,7 +31,7 @@
         
 		//Plugin magic goes here! Note that you cannot use the same layer object again, as that will confuse the two map controls
 		var osm2 = new L.TileLayer(osmUrl, {minZoom: 0, maxZoom: 13, attribution: osmAttrib });
-		var miniMap = new L.Control.MiniMap(osm2, { toggleDisplay: true }).addTo(map);
+		var miniMap = new L.Control.MiniMap(osm2).addTo(map);
     </script>
 </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,8 @@ As the minimap control inherits from leaflet's control, positioning is handled a
 
 `height:` The height of the minimap in pixels. Defaults to 150.
 
+`toggleDisplay:` When set to true, adds a button to minimize or maximize the minimap.
+
 `zoomLevelOffset:` The offset applied to the zoom in the minimap compared to the zoom of the main map. Can be positive or negative, defaults to -5.
 
 `zoomLevelFixed:` Overrides the offset to apply a fixed zoom level to the minimap regardless of the main map zoom. Set it to any valid zoom level, if unset `zoomLevelOffset` is used instead.


### PR DESCRIPTION
Updated the documentation to include the `toggleDisplay` option.  Also reverted the default example.html back to it's original state, without toggleDisplay set to `true`.
