### PR TITLE
Make compatible with Leaflet master

### DIFF
--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -175,7 +175,7 @@ L.Control.MiniMap = L.Control.extend({
 	},
 
 	_onMiniMapMoving: function (e) {
-		if (!this._mainMapMoving) {
+		if (!this._mainMapMoving && this._lastAimingRectPosition) {
 			this._shadowRect.setBounds(new L.LatLngBounds(this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.sw),this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.ne)));
 			this._shadowRect.setStyle({opacity:1,fillOpacity:0.3});
 		}


### PR DESCRIPTION
The order of events during layer initialization was changed in 
Leaflet/Leaflet@bd0bc4f2e56f3ccfe8d2817e2a213b0e1480ee26, resulting in
_onMiniMapMoving being called before _lastAimingRectPosition has been
initialized.
