### PR TITLE
Don't clone layer objects

### DIFF
--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -83,6 +83,7 @@ L.Control.MiniMap = L.Control.extend({
 		this._mainMap.off('move', this._onMainMapMoving, this);
 		this._miniMap.off('moveend', this._onMiniMapMoved, this);
 
+		this._miniMap.removeLayer(this._layer);
 	},
 
 	_addToggleButton: function () {


### PR DESCRIPTION
In general, layers aren't safe to clone -- they may contain references to the
map, to themselves, to arbitrary other objects which should not be cloned.

The example for which cloning was added has since been removed anyway
(6afda200, c1ee4381).
