### PR TITLE
Add an option to listen to main map baselayer change

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,8 @@ As the minimap control inherits from leaflet's control, positioning is handled a
 
 `autoToggleDisplay:` Sets whether the minimap should hide automatically if the parent map bounds does not fit within the minimap bounds. Especially useful when 'zoomLevelFixed' is set.
 
+`listenBaseLayerChange:` Sets whether the minimap baselayer should change or not when main map baselayer is changed. Default to false.
+
 ###Translation strings
 
 These are not passed as options, but are overridden in a subclass. To do general translation overrides take a look at the german example sourcefile.

--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -6,6 +6,7 @@ L.Control.MiniMap = L.Control.extend({
 		zoomLevelFixed: false,
 		zoomAnimation: false,
 		autoToggleDisplay: false,
+		listenBaseLayerChange: false,
 		width: 150,
 		height: 150
 	},
@@ -17,7 +18,7 @@ L.Control.MiniMap = L.Control.extend({
 	//layer is the map layer to be shown in the minimap
 	initialize: function (layer, options) {
 		L.Util.setOptions(this, options);
-		this._layer = layer;
+		this._layer = this._cloneLayer(layer);
 	},
 	
 	onAdd: function (map) {
@@ -76,7 +77,19 @@ L.Control.MiniMap = L.Control.extend({
 		L.Control.prototype.addTo.call(this, map);
 		this._miniMap.setView(this._mainMap.getCenter(), this._decideZoom(true));
 		this._setDisplay(this._decideMinimized());
+		if (this.options.listenBaseLayerChange) {
+			this._mainMap.on('baselayerchange', this.onMainMapBaseLayerChange, this);
+		}
 		return this;
+	},
+
+	onMainMapBaseLayerChange: function (e) {
+		var layer = this._cloneLayer(e.layer);
+		if (this._miniMap.hasLayer(this._layer)) {
+			this._miniMap.removeLayer(this._layer);
+		}
+		this._layer = layer;
+		this._miniMap.addLayer(this._layer);
 	},
 
 	onRemove: function (map) {
@@ -225,6 +238,10 @@ L.Control.MiniMap = L.Control.extend({
 		}
 
 		return this._minimized;
+	},
+
+	_cloneLayer: function (layer) {
+		return new L.TileLayer(layer._url, layer.options);
 	}
 });
 


### PR DESCRIPTION
The idea is to listen to the [baselayerchange event](https://github.com/Leaflet/Leaflet/blob/master/src/control/Control.Layers.js#L229), fired by Leaflet. I've added an option to control this, and the default is `false` to respect the current behaviour.

As we cannot use a same `TileLayer` instance if both mainMap and miniMap, I've added a `_cloneLayer` method.

And while I was at it, I've called this method on the `initialize`, to make possible to pass an already used baselayer as argument. I don't think it can cost anything, but tell me if I'm wrong. If you agree, we should remove the warning in the README.

What do you think?

Thanks :)

Yohan
