### PR TITLE
Added ZoomSlider Plugin compatibility

### DIFF
--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -36,6 +36,7 @@ L.Control.MiniMap = L.Control.extend({
 		{
 			attributionControl: false,
 			zoomControl: false,
+			zoomsliderControl: false,
 			zoomAnimation: this.options.zoomAnimation,
 			autoToggleDisplay: this.options.autoToggleDisplay,
 			touchZoom: !this.options.zoomLevelFixed,


### PR DESCRIPTION
I've added zoomsliderControl:false to the map config so MiniMap and ZoomSilder plugins can be used together.
