### PR TITLE
Hide zoomslider widget

### DIFF
--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -36,6 +36,7 @@ L.Control.MiniMap = L.Control.extend({
 		{
 			attributionControl: false,
 			zoomControl: false,
+			zoomsliderControl: false,
 			zoomAnimation: this.options.zoomAnimation,
 			autoToggleDisplay: this.options.autoToggleDisplay,
 			touchZoom: !this.options.zoomLevelFixed,


### PR DESCRIPTION
When using the Leaflet.zoomslider widget the control is attached to the minimap. This behaviour isn't desirable, as such, it should be removed.

https://github.com/kartena/Leaflet.zoomslider
