### PR TITLE
Fixing trailing comma in minimap object definition.

### DIFF
--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -252,7 +252,7 @@ L.Control.MiniMap = L.Control.extend({
 
 	_onMainMapResized: function (e) {
 		this._miniMap.invalidateSize();
-	},
+	}
 });
 
 L.Map.mergeOptions({


### PR DESCRIPTION
Minor fix for issue caused by IE7 trailing comma handling.
