### PR TITLE
CSS for IE < 9

### DIFF
--- a/src/Control.MiniMap.css
+++ b/src/Control.MiniMap.css
@@ -28,3 +28,16 @@
     bottom: 0;
     right: 0; 
 }
+
+/* Old IE */
+.leaflet-oldie .leaflet-control-minimap {
+	border: 1px solid #999;
+}
+
+.leaflet-oldie .leaflet-control-minimap a {
+	background-color: #fff;
+}
+
+.leaflet-oldie .leaflet-control-minimap a.minimized {
+	filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+}


### PR DESCRIPTION
I've created some css for IE < 9.

Features:
- icon is rotated by 180 degrees, when the MiniMap is minimized
- border around the minimap
- background for the icon
