### PR TITLE
Add a maxZoom option for the minimap

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ As the minimap control inherits from leaflet's control, positioning is handled a
 
 `zoomLevelOffset:` The offset applied to the zoom in the minimap compared to the zoom of the main map. Can be positive or negative, defaults to -5.
 
+`maxZoom:` The maximum zoom level for the minimap. Set to false to disable this feature. Defaults to false.
+
 `zoomLevelFixed:` Overrides the offset to apply a fixed zoom level to the minimap regardless of the main map zoom. Set it to any valid zoom level, if unset `zoomLevelOffset` is used instead.
 
 `zoomAnimation:` Sets whether the minimap should have an animated zoom. (Will cause it to lag a bit after the movement of the main map.) Defaults to false.

--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -3,6 +3,7 @@ L.Control.MiniMap = L.Control.extend({
 		position: 'bottomright',
 		toggleDisplay: false,
 		zoomLevelOffset: -5,
+                maxZoom: false,
 		zoomLevelFixed: false,
 		zoomAnimation: false,
 		autoToggleDisplay: false,
@@ -37,8 +38,7 @@ L.Control.MiniMap = L.Control.extend({
 		L.DomEvent.on(this._container, 'mousewheel', L.DomEvent.stopPropagation);
 
 
-		this._miniMap = new L.Map(this._container,
-		{
+		var miniMapOptions = {
 			attributionControl: false,
 			zoomControl: false,
 			zoomAnimation: this.options.zoomAnimation,
@@ -48,7 +48,11 @@ L.Control.MiniMap = L.Control.extend({
 			doubleClickZoom: !this.options.zoomLevelFixed,
 			boxZoom: !this.options.zoomLevelFixed,
 			crs: map.options.crs
-		});
+		};
+		if (this.options.maxZoom !== false){
+			miniMapOptions.maxZoom = this.options.maxZoom;
+		}
+		this._miniMap = new L.Map(this._container, miniMapOptions);
 
 		this._miniMap.addLayer(this._layer);
 
@@ -205,9 +209,14 @@ L.Control.MiniMap = L.Control.extend({
 
 	_decideZoom: function (fromMaintoMini) {
 		if (!this.options.zoomLevelFixed) {
-			if (fromMaintoMini)
-				return this._mainMap.getZoom() + this.options.zoomLevelOffset;
-			else {
+			if (fromMaintoMini) {
+				var zoom = this._mainMap.getZoom() + this.options.zoomLevelOffset;
+        			if (this.options.maxZoom !== false && zoom > this.options.maxZoom){
+          				return this.options.maxZoom;
+        			} else {
+          				return zoom;
+        			}
+			} else {
 				var currentDiff = this._miniMap.getZoom() - this._mainMap.getZoom();
 				var proposedZoom = this._miniMap.getZoom() - this.options.zoomLevelOffset;
 				var toRet;


### PR DESCRIPTION
A maximum zoom ensures there is always a minimum amount of context available when using `zoomLevelOffset`.
