### PR TITLE
Add centerFixed option when initializing MiniMap (to disable panning and/or zooming)

### DIFF
--- a/example/example_fixedcenter.html
+++ b/example/example_fixedcenter.html
@@ -31,7 +31,7 @@
 		//Plugin magic goes here! Note that you cannot use the same layer object again, as that will confuse the two map controls
 		var osm2 = new L.TileLayer(osmUrl, {minZoom: 0, maxZoom: 13, attribution: osmAttrib });
 		var miniMap = new L.Control.MiniMap(osm2, {
-			fixedCenter: [40.7842, -73.9919]
+			centerFixed: [40.7842, -73.9919]
 		}).addTo(map);
 	</script>
 </body>

--- a/example/example_fixedcenter.html
+++ b/example/example_fixedcenter.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>MiniMap Fixed Center Demo</title>
+	<meta charset="utf-8" />
+
+	<link rel="stylesheet" href="./fullscreen.css" />
+
+	<!-- Leaflet -->
+	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+	<script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet-src.js" type="text/javascript"></script>
+
+	<!-- Leaflet Plugins -->
+	<link rel="stylesheet" href="../src/Control.MiniMap.css" />
+	<script src="../src/Control.MiniMap.js" type="text/javascript"></script>
+
+</head>
+<body>
+		<div id="map" ></div>
+
+	<script type="text/javascript">
+
+		var map = new L.Map('map');
+		var osmUrl='http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+		var osmAttrib='Map data &copy; OpenStreetMap contributors';
+		var osm = new L.TileLayer(osmUrl, {minZoom: 5, maxZoom: 18, attribution: osmAttrib});
+
+		map.addLayer(osm);
+		map.setView(new L.LatLng(59.92448055859924, 10.758276373601069),10);
+
+		//Plugin magic goes here! Note that you cannot use the same layer object again, as that will confuse the two map controls
+		var osm2 = new L.TileLayer(osmUrl, {minZoom: 0, maxZoom: 13, attribution: osmAttrib });
+		var miniMap = new L.Control.MiniMap(osm2, {
+			fixedCenter: [40.7842, -73.9919]
+		}).addTo(map);
+	</script>
+</body>
+</html>

--- a/example/example_fixedview.html
+++ b/example/example_fixedview.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>MiniMap Fixed Zoom Demo</title>
+	<meta charset="utf-8" />
+
+	<link rel="stylesheet" href="./fullscreen.css" />
+
+	<!-- Leaflet -->
+	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+	<script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet-src.js" type="text/javascript"></script>
+
+	<!-- Leaflet Plugins -->
+	<link rel="stylesheet" href="../src/Control.MiniMap.css" />
+	<script src="../src/Control.MiniMap.js" type="text/javascript"></script>
+
+</head>
+<body>
+		<div id="map" ></div>
+
+	<script type="text/javascript">
+
+		var map = new L.Map('map');
+		var osmUrl='http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+		var osmAttrib='Map data &copy; OpenStreetMap contributors';
+		var osm = new L.TileLayer(osmUrl, {minZoom: 5, maxZoom: 18, attribution: osmAttrib});
+
+		map.addLayer(osm);
+		map.setView(new L.LatLng(59.92448055859924, 10.758276373601069),10);
+
+		//Plugin magic goes here! Note that you cannot use the same layer object again, as that will confuse the two map controls
+		var osm2 = new L.TileLayer(osmUrl, {minZoom: 0, maxZoom: 13, attribution: osmAttrib });
+		var miniMap = new L.Control.MiniMap(osm2, {
+			fixedCenter: [40.7842, -73.9919],
+			zoomLevelFixed: 15
+		}).addTo(map);
+	</script>
+</body>
+</html>

--- a/example/example_fixedview.html
+++ b/example/example_fixedview.html
@@ -31,7 +31,7 @@
 		//Plugin magic goes here! Note that you cannot use the same layer object again, as that will confuse the two map controls
 		var osm2 = new L.TileLayer(osmUrl, {minZoom: 0, maxZoom: 13, attribution: osmAttrib });
 		var miniMap = new L.Control.MiniMap(osm2, {
-			fixedCenter: [40.7842, -73.9919],
+			centerFixed: [40.7842, -73.9919],
 			zoomLevelFixed: 15
 		}).addTo(map);
 	</script>

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Leaflet.MiniMap is a simple minimap control that you can drop into your leaflet 
 The control can be inserted in two lines: First you have to construct a layer for it to use, and then you create and attach the minimap control. Don't reuse the layer you added to the main map, strange behaviour will ensue! Alternatively, you can pass in a LayerGroup with multiple layers (for example with overlays or suitably themed markers). Marker layers can't be reused either. (See issue #52 for a discussion of syncronising marker layers.)
 
 From the [example](http://norkart.github.com/Leaflet-MiniMap/example.html):
-    
+
     var osm2 = new L.TileLayer(osmUrl, {minZoom: 0, maxZoom: 13, attribution: osmAttrib});
     var miniMap = new L.Control.MiniMap(osm2).addTo(map);
 
@@ -22,7 +22,7 @@ As the minimap control inherits from leaflet's control, positioning is handled a
 
     var MiniMap = require('leaflet-minimap');
     new MiniMap(layer, options).addTo(map);
-    
+
 If you prefer ES6 style (for example with babel):
 
     import MiniMap from 'leaflet-minimap';
@@ -33,7 +33,7 @@ If you prefer ES6 style (for example with babel):
     require(['leaflet-minimap'], function(MiniMap) {
         new Minimap(layer, options).addTo(map);
     });
-    
+
 ## Available Methods
 
 `changeLayer:` Swaps out the minimap layer for the one provided. See the _layerchange_ example for hints on good uses.
@@ -55,9 +55,11 @@ If you prefer ES6 style (for example with babel):
 
 `zoomLevelFixed:` Overrides the offset to apply a fixed zoom level to the minimap regardless of the main map zoom. Set it to any valid zoom level, if unset `zoomLevelOffset` is used instead.
 
+`centerFixed`: Applies a fixed position to the minimap regardless of the main map's view / position. Prevents panning the minimap, but does allow zooming (both in the minimap and the main map). If the minimap is zoomed, it will always zoom around the `centerFixed` point. You can pass in a LatLng object or a LatLng-like array. Defaults to false.
+
 `zoomAnimation:` Sets whether the minimap should have an animated zoom. (Will cause it to lag a bit after the movement of the main map.) Defaults to false.
 
-`toggleDisplay:` Sets whether the minimap should have a button to minimise it. Defaults to false. 
+`toggleDisplay:` Sets whether the minimap should have a button to minimise it. Defaults to false.
 
 `autoToggleDisplay:` Sets whether the minimap should hide automatically if the parent map bounds does not fit within the minimap bounds. Especially useful when 'zoomLevelFixed' is set.
 
@@ -74,5 +76,5 @@ If you prefer ES6 style (for example with babel):
 `showText:` The text to be displayed as Tooltip when hovering over the toggle button on the MiniMap and it is hidden. Defaults to 'Show MiniMap'
 
 ##Building minified versions
-First, install node.js on your system. Then run `npm install` to get the dependencies, and `npm build` to build 
+First, install node.js on your system. Then run `npm install` to get the dependencies, and `npm build` to build
 the minified js and css.

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ If you prefer ES6 style (for example with babel):
 
 `zoomLevelFixed:` Overrides the offset to apply a fixed zoom level to the minimap regardless of the main map zoom. Set it to any valid zoom level, if unset `zoomLevelOffset` is used instead.
 
-`centerFixed`: Applies a fixed position to the minimap regardless of the main map's view / position. Prevents panning the minimap, but does allow zooming (both in the minimap and the main map). If the minimap is zoomed, it will always zoom around the `centerFixed` point. You can pass in a LatLng object or a LatLng-like array. Defaults to false.
+`centerFixed`: Applies a fixed position to the minimap regardless of the main map's view / position. Prevents panning the minimap, but does allow zooming (both in the minimap and the main map). If the minimap is zoomed, it will always zoom around the `centerFixed` point. You can pass in a LatLng-equivalent object. Defaults to false.
 
 `zoomAnimation:` Sets whether the minimap should have an animated zoom. (Will cause it to lag a bit after the movement of the main map.) Defaults to false.
 

--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -25,7 +25,7 @@
 			toggleDisplay: false,
 			zoomLevelOffset: -5,
 			zoomLevelFixed: false,
-      fixedCenter: false,
+      centerFixed: false,
 			zoomAnimation: false,
 			autoToggleDisplay: false,
 			width: 150,
@@ -60,13 +60,13 @@
 			this._miniMap = new L.Map(this._container,
 			{
 				attributionControl: false,
-        dragging: !this.options.fixedCenter,
+        dragging: !this.options.centerFixed,
 				zoomControl: false,
 				zoomAnimation: this.options.zoomAnimation,
 				autoToggleDisplay: this.options.autoToggleDisplay,
-				touchZoom: this.options.fixedCenter ? 'center' : !this._isZoomLevelFixed(),
-				scrollWheelZoom: this.options.fixedCenter ? 'center' : !this._isZoomLevelFixed(),
-				doubleClickZoom: this.options.fixedCenter ? 'center' : !this._isZoomLevelFixed(),
+				touchZoom: this.options.centerFixed ? 'center' : !this._isZoomLevelFixed(),
+				scrollWheelZoom: this.options.centerFixed ? 'center' : !this._isZoomLevelFixed(),
+				doubleClickZoom: this.options.centerFixed ? 'center' : !this._isZoomLevelFixed(),
 				boxZoom: !this._isZoomLevelFixed(),
 				crs: map.options.crs
 			});
@@ -101,7 +101,7 @@
 		addTo: function (map) {
 			L.Control.prototype.addTo.call(this, map);
 
-      var center = this.options.fixedCenter || this._mainMap.getCenter();
+      var center = this.options.centerFixed || this._mainMap.getCenter();
 			this._miniMap.setView(center, this._decideZoom(true));
 			this._setDisplay(this._decideMinimized());
 			return this;
@@ -199,7 +199,7 @@
 
 		_onMainMapMoved: function (e) {
       if (!this._miniMapMoving) {
-        var center = this.options.fixedCenter || this._mainMap.getCenter();
+        var center = this.options.centerFixed || this._mainMap.getCenter();
 
         this._mainMapMoving = true;
         this._miniMap.setView(center, this._decideZoom(true));
@@ -215,7 +215,7 @@
 		},
 
 		_onMiniMapMoveStarted:function (e) {
-      if (!this.options.fixedCenter) {
+      if (!this.options.centerFixed) {
         var lastAimingRect = this._aimingRect.getBounds();
         var sw = this._miniMap.latLngToContainerPoint(lastAimingRect.getSouthWest());
         var ne = this._miniMap.latLngToContainerPoint(lastAimingRect.getNorthEast());
@@ -224,7 +224,7 @@
 		},
 
 		_onMiniMapMoving: function (e) {
-      if (!this.options.fixedCenter) {
+      if (!this.options.centerFixed) {
         if (!this._mainMapMoving && this._lastAimingRectPosition) {
           this._shadowRect.setBounds(new L.LatLngBounds(this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.sw),this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.ne)));
           this._shadowRect.setStyle({opacity:1,fillOpacity:0.3});
@@ -234,7 +234,7 @@
 
 		_onMiniMapMoved: function (e) {
       if (!this._mainMapMoving) {
-        var center = this.options.fixedCenter || this._mainMap.getCenter();
+        var center = this.options.centerFixed || this._mainMap.getCenter();
 
         this._miniMapMoving = true;
         this._mainMap.setView(this._mainMap.getCenter(), this._decideZoom(false));

--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -25,6 +25,7 @@
 			toggleDisplay: false,
 			zoomLevelOffset: -5,
 			zoomLevelFixed: false,
+      fixedCenter: false,
 			zoomAnimation: false,
 			autoToggleDisplay: false,
 			width: 150,
@@ -35,7 +36,7 @@
 			shadowRectOptions: {color: "#000000", weight: 1, clickable: false, opacity:0, fillOpacity:0},
 			strings: {hideText: 'Hide MiniMap', showText: 'Show MiniMap'}
 		},
-		
+
 		//layer is the map layer to be shown in the minimap
 		initialize: function (layer, options) {
 			L.Util.setOptions(this, options);
@@ -44,46 +45,46 @@
 			this.options.shadowRectOptions.clickable = false;
 			this._layer = layer;
 		},
-		
+
 		onAdd: function (map) {
-	
+
 			this._mainMap = map;
-	
+
 			//Creating the container and stopping events from spilling through to the main map.
 			this._container = L.DomUtil.create('div', 'leaflet-control-minimap');
 			this._container.style.width = this.options.width + 'px';
 			this._container.style.height = this.options.height + 'px';
 			L.DomEvent.disableClickPropagation(this._container);
 			L.DomEvent.on(this._container, 'mousewheel', L.DomEvent.stopPropagation);
-	
-	
+
 			this._miniMap = new L.Map(this._container,
 			{
 				attributionControl: false,
+        dragging: !this.options.fixedCenter,
 				zoomControl: false,
 				zoomAnimation: this.options.zoomAnimation,
 				autoToggleDisplay: this.options.autoToggleDisplay,
-				touchZoom: !this._isZoomLevelFixed(),
-				scrollWheelZoom: !this._isZoomLevelFixed(),
-				doubleClickZoom: !this._isZoomLevelFixed(),
+				touchZoom: this.options.fixedCenter ? 'center' : !this._isZoomLevelFixed(),
+				scrollWheelZoom: this.options.fixedCenter ? 'center' : !this._isZoomLevelFixed(),
+				doubleClickZoom: this.options.fixedCenter ? 'center' : !this._isZoomLevelFixed(),
 				boxZoom: !this._isZoomLevelFixed(),
 				crs: map.options.crs
 			});
-	
+
 			this._miniMap.addLayer(this._layer);
-	
+
 			//These bools are used to prevent infinite loops of the two maps notifying each other that they've moved.
 			this._mainMapMoving = false;
 			this._miniMapMoving = false;
-	
+
 			//Keep a record of this to prevent auto toggling when the user explicitly doesn't want it.
 			this._userToggledDisplay = false;
 			this._minimized = false;
-	
+
 			if (this.options.toggleDisplay) {
 				this._addToggleButton();
 			}
-	
+
 			this._miniMap.whenReady(L.Util.bind(function () {
 				this._aimingRect = L.rectangle(this._mainMap.getBounds(), this.options.aimingRectOptions).addTo(this._miniMap);
 				this._shadowRect = L.rectangle(this._mainMap.getBounds(), this.options.shadowRectOptions).addTo(this._miniMap);
@@ -93,58 +94,60 @@
 				this._miniMap.on('move', this._onMiniMapMoving, this);
 				this._miniMap.on('moveend', this._onMiniMapMoved, this);
 			}, this));
-	
+
 			return this._container;
 		},
-	
+
 		addTo: function (map) {
 			L.Control.prototype.addTo.call(this, map);
-			this._miniMap.setView(this._mainMap.getCenter(), this._decideZoom(true));
+
+      var center = this.options.fixedCenter || this._mainMap.getCenter();
+			this._miniMap.setView(center, this._decideZoom(true));
 			this._setDisplay(this._decideMinimized());
 			return this;
 		},
-	
+
 		onRemove: function (map) {
 			this._mainMap.off('moveend', this._onMainMapMoved, this);
 			this._mainMap.off('move', this._onMainMapMoving, this);
 			this._miniMap.off('moveend', this._onMiniMapMoved, this);
-	
+
 			this._miniMap.removeLayer(this._layer);
 		},
-		
+
 		changeLayer: function (layer) {
 	           this._miniMap.removeLayer(this._layer);
 	           this._layer = layer;
 	           this._miniMap.addLayer(this._layer);
 	    },
-	
-		_addToggleButton: function () {	
+
+		_addToggleButton: function () {
 			this._toggleDisplayButton = this.options.toggleDisplay ? this._createButton(
-					'', this.options.strings.hideText, ('leaflet-control-minimap-toggle-display leaflet-control-minimap-toggle-display-' 
+					'', this.options.strings.hideText, ('leaflet-control-minimap-toggle-display leaflet-control-minimap-toggle-display-'
 					+ this.options.position), this._container, this._toggleDisplayButtonClicked, this) : undefined;
-			
+
 			this._toggleDisplayButton.style.width = this.options.collapsedWidth + 'px';
 			this._toggleDisplayButton.style.height = this.options.collapsedHeight + 'px';
 		},
-	
+
 		_createButton: function (html, title, className, container, fn, context) {
 			var link = L.DomUtil.create('a', className, container);
 			link.innerHTML = html;
 			link.href = '#';
 			link.title = title;
-	
+
 			var stop = L.DomEvent.stopPropagation;
-	
+
 			L.DomEvent
 				.on(link, 'click', stop)
 				.on(link, 'mousedown', stop)
 				.on(link, 'dblclick', stop)
 				.on(link, 'click', L.DomEvent.preventDefault)
 				.on(link, 'click', fn, context);
-	
+
 			return link;
 		},
-	
+
 		_toggleDisplayButtonClicked: function () {
 			this._userToggledDisplay = true;
 			if (!this._minimized) {
@@ -156,7 +159,7 @@
 				this._toggleDisplayButton.title = this.options.strings.hideText;
 			}
 		},
-	
+
 		_setDisplay: function (minimize) {
 			if (minimize != this._minimized) {
 				if (!this._minimized) {
@@ -167,7 +170,7 @@
 				}
 			}
 		},
-	
+
 		_minimize: function () {
 			// hide the minimap
 			if (this.options.toggleDisplay) {
@@ -180,7 +183,7 @@
 			}
 			this._minimized = true;
 		},
-	
+
 		_restore: function () {
 			if (this.options.toggleDisplay) {
 				this._container.style.width = this.options.width + 'px';
@@ -193,60 +196,68 @@
 			}
 			this._minimized = false;
 		},
-	
+
 		_onMainMapMoved: function (e) {
-			if (!this._miniMapMoving) {
-				this._mainMapMoving = true;
-				this._miniMap.setView(this._mainMap.getCenter(), this._decideZoom(true));
-				this._setDisplay(this._decideMinimized());
-			} else {
-				this._miniMapMoving = false;
-			}
-			this._aimingRect.setBounds(this._mainMap.getBounds());
+      if (!this._miniMapMoving) {
+        var center = this.options.fixedCenter || this._mainMap.getCenter();
+
+        this._mainMapMoving = true;
+        this._miniMap.setView(center, this._decideZoom(true));
+        this._setDisplay(this._decideMinimized());
+      } else {
+        this._miniMapMoving = false;
+      }
+      this._aimingRect.setBounds(this._mainMap.getBounds());
 		},
-	
+
 		_onMainMapMoving: function (e) {
 			this._aimingRect.setBounds(this._mainMap.getBounds());
 		},
-	
+
 		_onMiniMapMoveStarted:function (e) {
-			var lastAimingRect = this._aimingRect.getBounds();
-			var sw = this._miniMap.latLngToContainerPoint(lastAimingRect.getSouthWest());
-			var ne = this._miniMap.latLngToContainerPoint(lastAimingRect.getNorthEast());
-			this._lastAimingRectPosition = {sw:sw,ne:ne};
+      if (!this.options.fixedCenter) {
+        var lastAimingRect = this._aimingRect.getBounds();
+        var sw = this._miniMap.latLngToContainerPoint(lastAimingRect.getSouthWest());
+        var ne = this._miniMap.latLngToContainerPoint(lastAimingRect.getNorthEast());
+        this._lastAimingRectPosition = {sw:sw,ne:ne};
+      }
 		},
-	
+
 		_onMiniMapMoving: function (e) {
-			if (!this._mainMapMoving && this._lastAimingRectPosition) {
-				this._shadowRect.setBounds(new L.LatLngBounds(this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.sw),this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.ne)));
-				this._shadowRect.setStyle({opacity:1,fillOpacity:0.3});
-			}
+      if (!this.options.fixedCenter) {
+        if (!this._mainMapMoving && this._lastAimingRectPosition) {
+          this._shadowRect.setBounds(new L.LatLngBounds(this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.sw),this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.ne)));
+          this._shadowRect.setStyle({opacity:1,fillOpacity:0.3});
+        }
+      }
 		},
-	
+
 		_onMiniMapMoved: function (e) {
-			if (!this._mainMapMoving) {
-				this._miniMapMoving = true;
-				this._mainMap.setView(this._miniMap.getCenter(), this._decideZoom(false));
-				this._shadowRect.setStyle({opacity:0,fillOpacity:0});
-			} else {
-				this._mainMapMoving = false;
-			}
+      if (!this._mainMapMoving) {
+        var center = this.options.fixedCenter || this._mainMap.getCenter();
+
+        this._miniMapMoving = true;
+        this._mainMap.setView(this._mainMap.getCenter(), this._decideZoom(false));
+        this._shadowRect.setStyle({opacity:0,fillOpacity:0});
+      } else {
+        this._mainMapMoving = false;
+      }
 		},
 
     _isZoomLevelFixed:function() {
       var zoomLevelFixed = this.options.zoomLevelFixed;
       return this._isDefined(zoomLevelFixed) && this._isInteger(zoomLevelFixed);
     },
-	
+
 		_decideZoom: function (fromMaintoMini) {
-			if (!this._isZoomLevelFixed()){ 
+			if (!this._isZoomLevelFixed()){
 				if (fromMaintoMini)
 					return this._mainMap.getZoom() + this.options.zoomLevelOffset;
 				else {
 					var currentDiff = this._miniMap.getZoom() - this._mainMap.getZoom();
 					var proposedZoom = this._miniMap.getZoom() - this.options.zoomLevelOffset;
 					var toRet;
-					
+
 					if (currentDiff > this.options.zoomLevelOffset && this._mainMap.getZoom() < this._miniMap.getMinZoom() - this.options.zoomLevelOffset) {
 						//This means the miniMap is zoomed out to the minimum zoom level and can't zoom any more.
 						if (this._miniMap.getZoom() > this._lastMiniMapZoom) {
@@ -273,19 +284,19 @@
 					return this._mainMap.getZoom();
 			}
 		},
-	
+
 		_decideMinimized: function () {
 			if (this._userToggledDisplay) {
 				return this._minimized;
 			}
-	
+
 			if (this.options.autoToggleDisplay) {
 				if (this._mainMap.getBounds().contains(this._miniMap.getBounds())) {
 					return true;
 				}
 				return false;
 			}
-	
+
 			return this._minimized;
     },
 
@@ -297,17 +308,17 @@
       return typeof value !== 'undefined';
     },
 	});
-	
+
 	L.Map.mergeOptions({
 		miniMapControl: false
 	});
-	
+
 	L.Map.addInitHook(function () {
 		if (this.options.miniMapControl) {
 			this.miniMapControl = (new MiniMap()).addTo(this);
 		}
 	});
-	
+
 	return MiniMap;
-	
-}, window)); 
+
+}, window));


### PR DESCRIPTION
Closes #94
Closes #77

This PR adds a new option, `centerFixed`, that fixes the MiniMap on a point, but still allows zooming. When `centerFixed` is enabled, the MiniMap won't change when the main map is panned - only if it's zoomed, and when it's zoomed, the MiniMap will always zoom centered around the point passed on initialization.

```js
var miniMap = new L.Control.MiniMap(osm2, {
  centerFixed: [40.7842, -73.9919]
}).addTo(map);
```

If you want to disable panning and zooming (ala #77), just initialize a MiniMap with both `centerFixed` and `zoomLevelFixed`, like this:

```js
var miniMap = new L.Control.MiniMap(osm2, {
  centerFixed: [40.7842, -73.9919],
  zoomLevelFixed: 15
}).addTo(map);
```

This PR also adds examples for creating both a MiniMap with a fixed center and a MiniMap with a fixed view (ie. no panning or zooming).

:memo: NOTE: The indentation in this file was already a bit of a mess (tabs and spaces mixed together) - I'd be happy to fix this and change it to use all tabs in another PR if that's everyone's preference, but I didn't want to do it in this one to keep the diff more readable. My editor also removed some trailing whitespace as I worked - if that's an issue, I can revert those changes too. Otherwise, I plan on submitting another PR to fix the formatting and stuff, if that would be :cool: