### PR TITLE
Clean-up code style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: node_js
+node_js:
+  - node
+  - "0.12"

--- a/package.json
+++ b/package.json
@@ -24,16 +24,24 @@
     "leaflet": ">=0.7.3"
   },
   "devDependencies": {
-    "uglify-js": "2.4.16",
     "clean-css": "3.0.7",
+    "happiness": "^1.0.7",
     "ncp": "1.0.1",
+    "svg2png": "1.1.0",
     "svgo": "0.5.0",
-    "svg2png": "1.1.0"
+    "uglify-js": "2.4.16"
   },
   "scripts": {
     "build:js": "uglifyjs  --output dist/Control.MiniMap.min.js src/Control.MiniMap.js",
     "build:css": "cleancss  --skip-rebase --output dist/Control.MiniMap.min.css src/Control.MiniMap.css",
     "build:img": "svgo src/images/toggle.svg dist/images/toggle.svg && node buildscripts/svgtopng.js",
-    "build": "npm run build:css && npm run build:js && npm run build:img"
+    "build": "npm run build:css && npm run build:js && npm run build:img",
+    "test": "happiness src/**/*.js"
+  },
+  "happiness": {
+    "globals": [
+      "define",
+      "L"
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Leaflet.MiniMap
 
-Leaflet.MiniMap is a simple minimap control that you can drop into your leaflet map, and it will create a small map in the corner which shows the same as the main map with a set zoom offset. (By default it is -5.)
+Leaflet.MiniMap is a simple minimap control that you can drop into your leaflet map, and it will create a small map in the corner which shows the same as the main map with a set zoom offset. (By default it is `-5`.)
 
 [![npm version](https://badge.fury.io/js/leaflet-minimap.svg)](https://www.npmjs.com/package/leaflet-minimap)
 [![Bower version](https://badge.fury.io/bo/leaflet-minimap.svg)](https://github.com/Norkart/Leaflet-MiniMap)
@@ -8,74 +8,80 @@ Leaflet.MiniMap is a simple minimap control that you can drop into your leaflet 
 
 ## Using the MiniMap control
 
-The control can be inserted in two lines: First you have to construct a layer for it to use, and then you create and attach the minimap control. Don't reuse the layer you added to the main map, strange behaviour will ensue! Alternatively, you can pass in a LayerGroup with multiple layers (for example with overlays or suitably themed markers). Marker layers can't be reused either. (See issue #52 for a discussion of syncronising marker layers.)
+The control can be inserted in two lines: First you have to construct a layer for it to use, and then you create and attach the minimap control. Don't reuse the layer you added to the main map, strange behaviour will ensue! Alternatively, you can pass in a LayerGroup with multiple layers (for example with overlays or suitably themed markers). Marker layers can't be reused either. (See issue #52 for a discussion of synchronising marker layers.)
 
 From the [example](http://norkart.github.com/Leaflet-MiniMap/example.html):
 
-    var osm2 = new L.TileLayer(osmUrl, {minZoom: 0, maxZoom: 13, attribution: osmAttrib});
-    var miniMap = new L.Control.MiniMap(osm2).addTo(map);
+```js
+var osm2 = new L.TileLayer(osmUrl, {minZoom: 0, maxZoom: 13, attribution: osmAttrib});
+var miniMap = new L.Control.MiniMap(osm2).addTo(map);
+```
 
 As the minimap control inherits from leaflet's control, positioning is handled automatically by leaflet. However, you can still style the minimap and set its size by modifying the css file.
 
 **Note:** Leaflet version 0.7.3 or higher is required.
 
-###Example usage in CommonJS compatible environments (Node/Browserify)
+### Example usage in CommonJS compatible environments (Node/Browserify)
 
-    var MiniMap = require('leaflet-minimap');
-    new MiniMap(layer, options).addTo(map);
-
+```js
+var MiniMap = require('leaflet-minimap');
+new MiniMap(layer, options).addTo(map);
+```
 If you prefer ES6 style (for example with babel):
 
-    import MiniMap from 'leaflet-minimap';
-    new MiniMap(layer, options).addTo(map);
+```js
+import MiniMap from 'leaflet-minimap';
+new MiniMap(layer, options).addTo(map);
+```
+### Example usage in AMD compatible environments (RequireJS)
 
-###Example usage in AMD compatible environments (RequireJS)
-
-    require(['leaflet-minimap'], function(MiniMap) {
-        new Minimap(layer, options).addTo(map);
-    });
+```js
+require(['leaflet-minimap'], function(MiniMap) {
+  new Minimap(layer, options).addTo(map);
+});
+```
 
 ## Available Methods
 
-`changeLayer:` Swaps out the minimap layer for the one provided. See the _layerchange_ example for hints on good uses.
+`changeLayer`: Swaps out the minimap layer for the one provided. See the _layerchange_ example for hints on good uses.
 
 ## Available Options
  The mini map uses options which can be set in the same way as other leaflet options, and these are the available options:
 
-`position:` The standard Leaflet.Control position parameter, used like all the other controls. Defaults to 'bottomright'.
+`position`: The standard Leaflet.Control position parameter, used like all the other controls. Defaults to 'bottomright'.
 
-`width:` The width of the minimap in pixels. Defaults to 150.
+`width`: The width of the minimap in pixels. Defaults to 150.
 
-`height:` The height of the minimap in pixels. Defaults to 150.
+`height`: The height of the minimap in pixels. Defaults to 150.
 
-`collapsedWidth:` The width of the toggle marker and the minimap when collapsed, in pixels. Defaults to 19.
+`collapsedWidth`: The width of the toggle marker and the minimap when collapsed, in pixels. Defaults to 19.
 
-`collapsedHeight:` The height of the toggle marker and the minimap when collapsed, in pixels. Defaults to 19.
+`collapsedHeight`: The height of the toggle marker and the minimap when collapsed, in pixels. Defaults to 19.
 
-`zoomLevelOffset:` The offset applied to the zoom in the minimap compared to the zoom of the main map. Can be positive or negative, defaults to -5.
+`zoomLevelOffset`: The offset applied to the zoom in the minimap compared to the zoom of the main map. Can be positive or negative, defaults to -5.
 
-`zoomLevelFixed:` Overrides the offset to apply a fixed zoom level to the minimap regardless of the main map zoom. Set it to any valid zoom level, if unset `zoomLevelOffset` is used instead.
+`zoomLevelFixed`: Overrides the offset to apply a fixed zoom level to the minimap regardless of the main map zoom. Set it to any valid zoom level, if unset `zoomLevelOffset` is used instead.
 
 `centerFixed`: Applies a fixed position to the minimap regardless of the main map's view / position. Prevents panning the minimap, but does allow zooming (both in the minimap and the main map). If the minimap is zoomed, it will always zoom around the `centerFixed` point. You can pass in a LatLng-equivalent object. Defaults to false.
 
-`zoomAnimation:` Sets whether the minimap should have an animated zoom. (Will cause it to lag a bit after the movement of the main map.) Defaults to false.
+`zoomAnimation`: Sets whether the minimap should have an animated zoom. (Will cause it to lag a bit after the movement of the main map.) Defaults to false.
 
-`toggleDisplay:` Sets whether the minimap should have a button to minimise it. Defaults to false.
+`toggleDisplay`: Sets whether the minimap should have a button to minimise it. Defaults to false.
 
-`autoToggleDisplay:` Sets whether the minimap should hide automatically if the parent map bounds does not fit within the minimap bounds. Especially useful when 'zoomLevelFixed' is set.
+`autoToggleDisplay`: Sets whether the minimap should hide automatically if the parent map bounds does not fit within the minimap bounds. Especially useful when 'zoomLevelFixed' is set.
 
-`aimingRectOptions:` Sets the style of the aiming rectangle by passing in a [Path.Options object](http://leafletjs.com/reference.html#path-options). (Clickable will always be overridden and set to false.)
+`aimingRectOptions`: Sets the style of the aiming rectangle by passing in a [Path.Options object](http://leafletjs.com/reference.html#path-options). (Clickable will always be overridden and set to false.)
 
-`shadowRectOptions:` Sets the style of the aiming shadow rectangle by passing in a [Path.Options object](http://leafletjs.com/reference.html#path-options). (Clickable will always be overridden and set to false.)
+`shadowRectOptions`: Sets the style of the aiming shadow rectangle by passing in a [Path.Options object](http://leafletjs.com/reference.html#path-options). (Clickable will always be overridden and set to false.)
 
-`strings:` Overrides the default strings allowing for translation. See below for available strings and `example/example_i18n.html` for an example.
+`strings`: Overrides the default strings allowing for translation. See below for available strings and `example/example_i18n.html` for an example.
 
 ### Available Strings
 
-`hideText:` The text to be displayed as Tooltip when hovering over the toggle button on the MiniMap and it is visible. Defaults to 'Hide MiniMap'
+`hideText`: The text to be displayed as Tooltip when hovering over the toggle button on the MiniMap and it is visible. Defaults to 'Hide MiniMap'
 
-`showText:` The text to be displayed as Tooltip when hovering over the toggle button on the MiniMap and it is hidden. Defaults to 'Show MiniMap'
+`showText`: The text to be displayed as Tooltip when hovering over the toggle button on the MiniMap and it is hidden. Defaults to 'Show MiniMap'
 
-##Building minified versions
+## Building minified versions
 First, install node.js on your system. Then run `npm install` to get the dependencies, and `npm build` to build
 the minified js and css.

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@ Leaflet.MiniMap is a simple minimap control that you can drop into your leaflet 
 
 [![npm version](https://badge.fury.io/js/leaflet-minimap.svg)](https://www.npmjs.com/package/leaflet-minimap)
 [![Bower version](https://badge.fury.io/bo/leaflet-minimap.svg)](https://github.com/Norkart/Leaflet-MiniMap)
+[![js-happiness-style](https://img.shields.io/badge/code%20style-happiness-brightgreen.svg?style=flat-square)](https://github.com/JedWatson/happiness)
 
 ## Using the MiniMap control
 

--- a/src/Control.MiniMap.css
+++ b/src/Control.MiniMap.css
@@ -1,77 +1,77 @@
 .leaflet-control-minimap {
-    border:solid rgba(255, 255, 255, 1.0) 4px;
-    box-shadow: 0 1px 5px rgba(0,0,0,0.65);
-    border-radius: 3px;
-    background: #f8f8f9;
-    transition: all .2s;
+	border:solid rgba(255, 255, 255, 1.0) 4px;
+	box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+	border-radius: 3px;
+	background: #f8f8f9;
+	transition: all .2s;
 }
 
 .leaflet-control-minimap a {
-    background-color: rgba(255, 255, 255, 1.0);
-    background-repeat: no-repeat;
-    z-index: 99999;
-    transition: all .2s;	
+	background-color: rgba(255, 255, 255, 1.0);
+	background-repeat: no-repeat;
+	z-index: 99999;
+	transition: all .2s;
 }
 
 .leaflet-control-minimap a.minimized-bottomright {
-    -webkit-transform: rotate(180deg);
-    transform: rotate(180deg);
-    border-radius: 0px;
+	-webkit-transform: rotate(180deg);
+	transform: rotate(180deg);
+	border-radius: 0px;
 }
 
 .leaflet-control-minimap a.minimized-topleft {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-    border-radius: 0px;
+	-webkit-transform: rotate(0deg);
+	transform: rotate(0deg);
+	border-radius: 0px;
 }
 
 .leaflet-control-minimap a.minimized-bottomleft {
-    -webkit-transform: rotate(270deg);
-    transform: rotate(270deg);
-    border-radius: 0px;
+	-webkit-transform: rotate(270deg);
+	transform: rotate(270deg);
+	border-radius: 0px;
 }
 
 .leaflet-control-minimap a.minimized-topright {
-    -webkit-transform: rotate(90deg);
-    transform: rotate(90deg);
-    border-radius: 0px;
+	-webkit-transform: rotate(90deg);
+	transform: rotate(90deg);
+	border-radius: 0px;
 }
 
 .leaflet-control-minimap-toggle-display{
-    background-image: url("images/toggle.svg");
+	background-image: url("images/toggle.svg");
 	background-size: cover;
-    position: absolute;
-    border-radius: 3px 0px 0px 0px;
+	position: absolute;
+	border-radius: 3px 0px 0px 0px;
 }
 
 .leaflet-oldie .leaflet-control-minimap-toggle-display{
-    background-image: url("images/toggle.png");
+	background-image: url("images/toggle.png");
 }
 
 .leaflet-control-minimap-toggle-display-bottomright {
-    bottom: 0;
-    right: 0; 
+	bottom: 0;
+	right: 0;
 }
 
 .leaflet-control-minimap-toggle-display-topleft{
-    top: 0;
-    left: 0; 
-    -webkit-transform: rotate(180deg);
-    transform: rotate(180deg);
+	top: 0;
+	left: 0;
+	-webkit-transform: rotate(180deg);
+	transform: rotate(180deg);
 }
 
 .leaflet-control-minimap-toggle-display-bottomleft{
-    bottom: 0;
-    left: 0; 
-    -webkit-transform: rotate(90deg);
-    transform: rotate(90deg);
+	bottom: 0;
+	left: 0;
+	-webkit-transform: rotate(90deg);
+	transform: rotate(90deg);
 }
 
 .leaflet-control-minimap-toggle-display-topright{
-    top: 0;
-    right: 0; 
-    -webkit-transform: rotate(270deg);
-    transform: rotate(270deg);
+	top: 0;
+	right: 0;
+	-webkit-transform: rotate(270deg);
+	transform: rotate(270deg);
 }
 
 /* Old IE */

--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -1,4 +1,4 @@
-// Following https://github.com/Leaflet/Leaflet/blob/master/PLUGIN-GUIDE.md
+// Following https:// github.com/Leaflet/Leaflet/blob/master/PLUGIN-GUIDE.md
 (function (factory, window) {
 
 	// define an AMD module that relies on 'leaflet'
@@ -32,15 +32,15 @@
 			height: 150,
 			collapsedWidth: 19,
 			collapsedHeight: 19,
-			aimingRectOptions: {color: "#ff7800", weight: 1, clickable: false},
-			shadowRectOptions: {color: "#000000", weight: 1, clickable: false, opacity:0, fillOpacity:0},
+			aimingRectOptions: {color: '#ff7800', weight: 1, clickable: false},
+			shadowRectOptions: {color: '#000000', weight: 1, clickable: false, opacity: 0, fillOpacity: 0},
 			strings: {hideText: 'Hide MiniMap', showText: 'Show MiniMap'}
 		},
 
-		//layer is the map layer to be shown in the minimap
+		// layer is the map layer to be shown in the minimap
 		initialize: function (layer, options) {
 			L.Util.setOptions(this, options);
-			//Make sure the aiming rects are non-clickable even if the user tries to set them clickable (most likely by forgetting to specify them false)
+			// Make sure the aiming rects are non-clickable even if the user tries to set them clickable (most likely by forgetting to specify them false)
 			this.options.aimingRectOptions.clickable = false;
 			this.options.shadowRectOptions.clickable = false;
 			this._layer = layer;
@@ -50,7 +50,7 @@
 
 			this._mainMap = map;
 
-			//Creating the container and stopping events from spilling through to the main map.
+			// Creating the container and stopping events from spilling through to the main map.
 			this._container = L.DomUtil.create('div', 'leaflet-control-minimap');
 			this._container.style.width = this.options.width + 'px';
 			this._container.style.height = this.options.height + 'px';
@@ -73,11 +73,11 @@
 
 			this._miniMap.addLayer(this._layer);
 
-			//These bools are used to prevent infinite loops of the two maps notifying each other that they've moved.
+			// These bools are used to prevent infinite loops of the two maps notifying each other that they've moved.
 			this._mainMapMoving = false;
 			this._miniMapMoving = false;
 
-			//Keep a record of this to prevent auto toggling when the user explicitly doesn't want it.
+			// Keep a record of this to prevent auto toggling when the user explicitly doesn't want it.
 			this._userToggledDisplay = false;
 			this._minimized = false;
 
@@ -123,8 +123,8 @@
 
 		_addToggleButton: function () {
 			this._toggleDisplayButton = this.options.toggleDisplay ? this._createButton(
-				'', this.options.strings.hideText, ('leaflet-control-minimap-toggle-display leaflet-control-minimap-toggle-display-'
-				+ this.options.position), this._container, this._toggleDisplayButtonClicked, this) : undefined;
+				'', this.options.strings.hideText, ('leaflet-control-minimap-toggle-display leaflet-control-minimap-toggle-display-' +
+				this.options.position), this._container, this._toggleDisplayButtonClicked, this) : undefined;
 
 			this._toggleDisplayButton.style.width = this.options.collapsedWidth + 'px';
 			this._toggleDisplayButton.style.height = this.options.collapsedHeight + 'px';
@@ -160,7 +160,7 @@
 		},
 
 		_setDisplay: function (minimize) {
-			if (minimize != this._minimized) {
+			if (minimize !== this._minimized) {
 				if (!this._minimized) {
 					this._minimize();
 				} else {
@@ -210,74 +210,73 @@
 			this._aimingRect.setBounds(this._mainMap.getBounds());
 		},
 
-		_onMiniMapMoveStarted:function (e) {
+		_onMiniMapMoveStarted: function (e) {
 			if (!this.options.centerFixed) {
 				var lastAimingRect = this._aimingRect.getBounds();
 				var sw = this._miniMap.latLngToContainerPoint(lastAimingRect.getSouthWest());
 				var ne = this._miniMap.latLngToContainerPoint(lastAimingRect.getNorthEast());
-				this._lastAimingRectPosition = {sw:sw,ne:ne};
+				this._lastAimingRectPosition = {sw: sw, ne: ne};
 			}
 		},
 
 		_onMiniMapMoving: function (e) {
 			if (!this.options.centerFixed) {
 				if (!this._mainMapMoving && this._lastAimingRectPosition) {
-					this._shadowRect.setBounds(new L.LatLngBounds(this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.sw),this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.ne)));
-					this._shadowRect.setStyle({opacity:1,fillOpacity:0.3});
+					this._shadowRect.setBounds(new L.LatLngBounds(this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.sw), this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.ne)));
+					this._shadowRect.setStyle({opacity: 1, fillOpacity: 0.3});
 				}
 			}
 		},
 
 		_onMiniMapMoved: function (e) {
 			if (!this._mainMapMoving) {
-				var center = this.options.centerFixed || this._mainMap.getCenter();
-
 				this._miniMapMoving = true;
 				this._mainMap.setView(this._mainMap.getCenter(), this._decideZoom(false));
-				this._shadowRect.setStyle({opacity:0,fillOpacity:0});
+				this._shadowRect.setStyle({opacity: 0, fillOpacity: 0});
 			} else {
 				this._mainMapMoving = false;
 			}
 		},
 
-		_isZoomLevelFixed:function() {
+		_isZoomLevelFixed: function () {
 			var zoomLevelFixed = this.options.zoomLevelFixed;
 			return this._isDefined(zoomLevelFixed) && this._isInteger(zoomLevelFixed);
 		},
 
 		_decideZoom: function (fromMaintoMini) {
-			if (!this._isZoomLevelFixed()){
-				if (fromMaintoMini)
+			if (!this._isZoomLevelFixed()) {
+				if (fromMaintoMini) {
 					return this._mainMap.getZoom() + this.options.zoomLevelOffset;
-				else {
+				} else {
 					var currentDiff = this._miniMap.getZoom() - this._mainMap.getZoom();
 					var proposedZoom = this._miniMap.getZoom() - this.options.zoomLevelOffset;
 					var toRet;
 
 					if (currentDiff > this.options.zoomLevelOffset && this._mainMap.getZoom() < this._miniMap.getMinZoom() - this.options.zoomLevelOffset) {
-						//This means the miniMap is zoomed out to the minimum zoom level and can't zoom any more.
+						// This means the miniMap is zoomed out to the minimum zoom level and can't zoom any more.
 						if (this._miniMap.getZoom() > this._lastMiniMapZoom) {
-							//This means the user is trying to zoom in by using the minimap, zoom the main map.
+							// This means the user is trying to zoom in by using the minimap, zoom the main map.
 							toRet = this._mainMap.getZoom() + 1;
-							//Also we cheat and zoom the minimap out again to keep it visually consistent.
-							this._miniMap.setZoom(this._miniMap.getZoom() -1);
+							// Also we cheat and zoom the minimap out again to keep it visually consistent.
+							this._miniMap.setZoom(this._miniMap.getZoom() - 1);
 						} else {
-							//Either the user is trying to zoom out past the mini map's min zoom or has just panned using it, we can't tell the difference.
-							//Therefore, we ignore it!
+							// Either the user is trying to zoom out past the mini map's min zoom or has just panned using it, we can't tell the difference.
+							// Therefore, we ignore it!
 							toRet = this._mainMap.getZoom();
 						}
 					} else {
-						//This is what happens in the majority of cases, and always if you configure the min levels + offset in a sane fashion.
+						// This is what happens in the majority of cases, and always if you configure the min levels + offset in a sane fashion.
 						toRet = proposedZoom;
 					}
 					this._lastMiniMapZoom = this._miniMap.getZoom();
 					return toRet;
 				}
 			} else {
-				if (fromMaintoMini)
+				if (fromMaintoMini) {
 					return this.options.zoomLevelFixed;
-				else
+				} else {
 					return this._mainMap.getZoom();
+				}
 			}
 		},
 
@@ -296,13 +295,13 @@
 			return this._minimized;
 		},
 
-		_isInteger:function(value) {
+		_isInteger: function (value) {
 			return typeof value === 'number';
 		},
 
-		_isDefined:function(value) {
+		_isDefined: function (value) {
 			return typeof value !== 'undefined';
-		},
+		}
 	});
 
 	L.Map.mergeOptions({

--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -1,22 +1,22 @@
 // Following https://github.com/Leaflet/Leaflet/blob/master/PLUGIN-GUIDE.md
 (function (factory, window) {
 
-    // define an AMD module that relies on 'leaflet'
-    if (typeof define === 'function' && define.amd) {
-        define(['leaflet'], factory);
+	// define an AMD module that relies on 'leaflet'
+	if (typeof define === 'function' && define.amd) {
+		define(['leaflet'], factory);
 
-    // define a Common JS module that relies on 'leaflet'
-    } else if (typeof exports === 'object') {
-        module.exports = factory(require('leaflet'));
-    }
+	// define a Common JS module that relies on 'leaflet'
+	} else if (typeof exports === 'object') {
+		module.exports = factory(require('leaflet'));
+	}
 
-    // attach your plugin to the global 'L' variable
-    if (typeof window !== 'undefined' && window.L) {
-        window.L.Control.MiniMap = factory(L);
-        window.L.control.minimap = function (layer, options) {
-        	return new window.L.Control.MiniMap(layer, options);
-        };
-    }
+	// attach your plugin to the global 'L' variable
+	if (typeof window !== 'undefined' && window.L) {
+		window.L.Control.MiniMap = factory(L);
+		window.L.control.minimap = function (layer, options) {
+			return new window.L.Control.MiniMap(layer, options);
+		};
+	}
 }(function (L) {
 
 	var MiniMap = L.Control.extend({
@@ -25,7 +25,7 @@
 			toggleDisplay: false,
 			zoomLevelOffset: -5,
 			zoomLevelFixed: false,
-      centerFixed: false,
+			centerFixed: false,
 			zoomAnimation: false,
 			autoToggleDisplay: false,
 			width: 150,
@@ -60,7 +60,7 @@
 			this._miniMap = new L.Map(this._container,
 			{
 				attributionControl: false,
-        dragging: !this.options.centerFixed,
+				dragging: !this.options.centerFixed,
 				zoomControl: false,
 				zoomAnimation: this.options.zoomAnimation,
 				autoToggleDisplay: this.options.autoToggleDisplay,
@@ -101,7 +101,7 @@
 		addTo: function (map) {
 			L.Control.prototype.addTo.call(this, map);
 
-      var center = this.options.centerFixed || this._mainMap.getCenter();
+			var center = this.options.centerFixed || this._mainMap.getCenter();
 			this._miniMap.setView(center, this._decideZoom(true));
 			this._setDisplay(this._decideMinimized());
 			return this;
@@ -116,15 +116,15 @@
 		},
 
 		changeLayer: function (layer) {
-	           this._miniMap.removeLayer(this._layer);
-	           this._layer = layer;
-	           this._miniMap.addLayer(this._layer);
-	    },
+			this._miniMap.removeLayer(this._layer);
+			this._layer = layer;
+			this._miniMap.addLayer(this._layer);
+		},
 
 		_addToggleButton: function () {
 			this._toggleDisplayButton = this.options.toggleDisplay ? this._createButton(
-					'', this.options.strings.hideText, ('leaflet-control-minimap-toggle-display leaflet-control-minimap-toggle-display-'
-					+ this.options.position), this._container, this._toggleDisplayButtonClicked, this) : undefined;
+				'', this.options.strings.hideText, ('leaflet-control-minimap-toggle-display leaflet-control-minimap-toggle-display-'
+				+ this.options.position), this._container, this._toggleDisplayButtonClicked, this) : undefined;
 
 			this._toggleDisplayButton.style.width = this.options.collapsedWidth + 'px';
 			this._toggleDisplayButton.style.height = this.options.collapsedHeight + 'px';
@@ -153,8 +153,7 @@
 			if (!this._minimized) {
 				this._minimize();
 				this._toggleDisplayButton.title = this.options.strings.showText;
-			}
-			else {
+			} else {
 				this._restore();
 				this._toggleDisplayButton.title = this.options.strings.hideText;
 			}
@@ -164,8 +163,7 @@
 			if (minimize != this._minimized) {
 				if (!this._minimized) {
 					this._minimize();
-				}
-				else {
+				} else {
 					this._restore();
 				}
 			}
@@ -177,8 +175,7 @@
 				this._container.style.width = this.options.collapsedWidth + 'px';
 				this._container.style.height = this.options.collapsedHeight + 'px';
 				this._toggleDisplayButton.className += (' minimized-' + this.options.position);
-			}
-			else {
+			} else {
 				this._container.style.display = 'none';
 			}
 			this._minimized = true;
@@ -189,25 +186,24 @@
 				this._container.style.width = this.options.width + 'px';
 				this._container.style.height = this.options.height + 'px';
 				this._toggleDisplayButton.className = this._toggleDisplayButton.className
-						.replace('minimized-'  + this.options.position, '');
-			}
-			else {
+					.replace('minimized-'	+ this.options.position, '');
+			} else {
 				this._container.style.display = 'block';
 			}
 			this._minimized = false;
 		},
 
 		_onMainMapMoved: function (e) {
-      if (!this._miniMapMoving) {
-        var center = this.options.centerFixed || this._mainMap.getCenter();
+			if (!this._miniMapMoving) {
+				var center = this.options.centerFixed || this._mainMap.getCenter();
 
-        this._mainMapMoving = true;
-        this._miniMap.setView(center, this._decideZoom(true));
-        this._setDisplay(this._decideMinimized());
-      } else {
-        this._miniMapMoving = false;
-      }
-      this._aimingRect.setBounds(this._mainMap.getBounds());
+				this._mainMapMoving = true;
+				this._miniMap.setView(center, this._decideZoom(true));
+				this._setDisplay(this._decideMinimized());
+			} else {
+				this._miniMapMoving = false;
+			}
+			this._aimingRect.setBounds(this._mainMap.getBounds());
 		},
 
 		_onMainMapMoving: function (e) {
@@ -215,39 +211,39 @@
 		},
 
 		_onMiniMapMoveStarted:function (e) {
-      if (!this.options.centerFixed) {
-        var lastAimingRect = this._aimingRect.getBounds();
-        var sw = this._miniMap.latLngToContainerPoint(lastAimingRect.getSouthWest());
-        var ne = this._miniMap.latLngToContainerPoint(lastAimingRect.getNorthEast());
-        this._lastAimingRectPosition = {sw:sw,ne:ne};
-      }
+			if (!this.options.centerFixed) {
+				var lastAimingRect = this._aimingRect.getBounds();
+				var sw = this._miniMap.latLngToContainerPoint(lastAimingRect.getSouthWest());
+				var ne = this._miniMap.latLngToContainerPoint(lastAimingRect.getNorthEast());
+				this._lastAimingRectPosition = {sw:sw,ne:ne};
+			}
 		},
 
 		_onMiniMapMoving: function (e) {
-      if (!this.options.centerFixed) {
-        if (!this._mainMapMoving && this._lastAimingRectPosition) {
-          this._shadowRect.setBounds(new L.LatLngBounds(this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.sw),this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.ne)));
-          this._shadowRect.setStyle({opacity:1,fillOpacity:0.3});
-        }
-      }
+			if (!this.options.centerFixed) {
+				if (!this._mainMapMoving && this._lastAimingRectPosition) {
+					this._shadowRect.setBounds(new L.LatLngBounds(this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.sw),this._miniMap.containerPointToLatLng(this._lastAimingRectPosition.ne)));
+					this._shadowRect.setStyle({opacity:1,fillOpacity:0.3});
+				}
+			}
 		},
 
 		_onMiniMapMoved: function (e) {
-      if (!this._mainMapMoving) {
-        var center = this.options.centerFixed || this._mainMap.getCenter();
+			if (!this._mainMapMoving) {
+				var center = this.options.centerFixed || this._mainMap.getCenter();
 
-        this._miniMapMoving = true;
-        this._mainMap.setView(this._mainMap.getCenter(), this._decideZoom(false));
-        this._shadowRect.setStyle({opacity:0,fillOpacity:0});
-      } else {
-        this._mainMapMoving = false;
-      }
+				this._miniMapMoving = true;
+				this._mainMap.setView(this._mainMap.getCenter(), this._decideZoom(false));
+				this._shadowRect.setStyle({opacity:0,fillOpacity:0});
+			} else {
+				this._mainMapMoving = false;
+			}
 		},
 
-    _isZoomLevelFixed:function() {
-      var zoomLevelFixed = this.options.zoomLevelFixed;
-      return this._isDefined(zoomLevelFixed) && this._isInteger(zoomLevelFixed);
-    },
+		_isZoomLevelFixed:function() {
+			var zoomLevelFixed = this.options.zoomLevelFixed;
+			return this._isDefined(zoomLevelFixed) && this._isInteger(zoomLevelFixed);
+		},
 
 		_decideZoom: function (fromMaintoMini) {
 			if (!this._isZoomLevelFixed()){
@@ -298,15 +294,15 @@
 			}
 
 			return this._minimized;
-    },
+		},
 
-    _isInteger:function(value) {
-      return typeof value === 'number';
-    },
+		_isInteger:function(value) {
+			return typeof value === 'number';
+		},
 
-    _isDefined:function(value) {
-      return typeof value !== 'undefined';
-    },
+		_isDefined:function(value) {
+			return typeof value !== 'undefined';
+		},
 	});
 
 	L.Map.mergeOptions({


### PR DESCRIPTION
Refs https://github.com/Norkart/Leaflet-MiniMap/pull/95

This PR fixes the code style of Leaflet-MiniMap's `src` files, adopts the [happiness](https://github.com/JedWatson/happiness) code style, and enforces this code style via the addition of CI configuration. This also fixes a few style things here and there in the Readme.

@robpvn If this looks good to you, would you mind enabling this repo on [Travis](https://travis-ci.org/)? Thanks!

:beers: 