### PR TITLE
Use L.Evented instead L.Mixin.Events when possible

### DIFF
--- a/src/Control.MiniMap.js
+++ b/src/Control.MiniMap.js
@@ -21,7 +21,7 @@
 
 	var MiniMap = L.Control.extend({
 
-		includes: L.Mixin.Events,
+		includes: L.Evented ? L.Evented.prototype : L.Mixin.Events,
 
 		options: {
 			position: 'bottomright',


### PR DESCRIPTION
L.Evented is present in Leaflet v1+
L.Mixin.Events is legacy; was deprecated in Leaflet v1 and will start
logging deprecation warnings in console after v1.0.3

Changes same as here:
https://github.com/mapzen/leaflet-geocoder/commit/a215a53b993d2fd071e75ae494906f49687b9aad