### PR TITLE
update SVGO and other devDependencies

### DIFF
--- a/buildscripts/svgtopng.js
+++ b/buildscripts/svgtopng.js
@@ -1,7 +1,7 @@
-var svg2png = require('svg2png');
-var ncp = require('ncp');
-var path = require('path');
+const fs = require("pn/fs"); // https://www.npmjs.com/package/pn
+const svg2png = require("svg2png");
 
-svg2png(path.resolve('src/images/toggle.svg'), path.resolve('src/images/toggle.png'), 1.0, function (err) {
-	ncp('src/images/toggle.png', 'dist/images/toggle.png');
-});
+fs.readFile("src/images/toggle.svg")
+    .then(svg2png)
+    .then(buffer => fs.writeFile("dist/images/toggle.png", buffer))
+    .catch(e => console.error(e));

--- a/package.json
+++ b/package.json
@@ -20,19 +20,20 @@
   "bugs": {
     "url": "https://github.com/Norkart/Leaflet-MiniMap/issues"
   },
+  "dependencies": {
+    "leaflet": "^1.0.3"
+  },
   "devDependencies": {
-    "clean-css": "3.0.7",
+    "clean-css-cli": "^4.2.1",
     "happiness": "^1.0.7",
-    "leaflet": ">=1.0.3",
-    "ncp": "1.0.1",
-    "svg2png": "1.1.0",
-    "svgo": "0.5.0",
-    "uglify-js": "2.6.0"
+    "svg2png": "^4.1.1",
+    "svgo": "^1.2.0",
+    "uglify-js": "^3.4.10"
   },
   "scripts": {
     "build:js": "uglifyjs  --output dist/Control.MiniMap.min.js src/Control.MiniMap.js",
     "build:css": "cleancss  --skip-rebase --output dist/Control.MiniMap.min.css src/Control.MiniMap.css",
-    "build:img": "svgo src/images/toggle.svg dist/images/toggle.svg && node buildscripts/svgtopng.js",
+    "build:img": "svgo src/images/toggle.svg -o dist/images/toggle.svg && node buildscripts/svgtopng.js",
     "build": "npm run build:css && npm run build:js && npm run build:img",
     "test": "happiness src/**/*.js",
     "preversion": "npm test && npm run build"


### PR DESCRIPTION
Alternative to #145

N.B.:
* `happiness` left heavily outdated
* `svgtopng.js`: unmodified sample code from https://github.com/domenic/svg2png/blob/master/README.md
  Although current `svg2png` already has cli support we still need helper buildscript
  because builtin cli lacks overwrite option (https://github.com/domenic/svg2png/issues/100)
  In our current setup `dist\images\toggle.png` has to be overwritten during build process
* `leaflet` moved from `devDependencies` to `peerDependancies` as demanded by
  [PLUGIN-GUIDE](https://github.com/Leaflet/Leaflet/blob/master/PLUGIN-GUIDE.md#publishing-on-npm)